### PR TITLE
Fix lowercase

### DIFF
--- a/juno-1/README.md
+++ b/juno-1/README.md
@@ -25,7 +25,7 @@ export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
 ```
 
 ```bash
-git clone https://github.com/CosmosContracts/Juno
+git clone https://github.com/CosmosContracts/juno
 cd juno
 git checkout juno-1
 make build && make install


### PR DESCRIPTION
avoid error
```
 cd: juno: No such file or directory
 ```