### PR TITLE
docs: Fix grammar issue in GENESIS.md

### DIFF
--- a/GENESIS.md
+++ b/GENESIS.md
@@ -29,7 +29,7 @@ make install
 
 Delete the old `.juno` directory
 
-**NB** This will delete your validator private key, and all your configurations. So it from a development machine.
+**NB** This will delete your validator private key, and all your configurations. So do it from a development machine.
 
 ```
 rm -rf ~/.juno


### PR DESCRIPTION
**Description:**  

While reviewing the documentation, I noticed a small grammatical issue in one of the sentences:  

> "So it from a development machine."  

The word "do" was missing, which disrupted the flow and clarity of the sentence. I've updated it to:  

> "So do it from a development machine."  

This change ensures the sentence is grammatically correct and easier to understand.